### PR TITLE
Update cognitive complexity rule

### DIFF
--- a/rule/cognitive_complexity.go
+++ b/rule/cognitive_complexity.go
@@ -83,9 +83,8 @@ func (w cognitiveComplexityLinter) lintCognitiveComplexity() {
 }
 
 type cognitiveComplexityVisitor struct {
-	name         *ast.Ident
-	complexity   int
-	nestingLevel int
+	name       *ast.Ident
+	complexity int
 }
 
 // subTreeComplexity calculates the cognitive complexity of an AST-subtree.
@@ -117,7 +116,7 @@ func (v *cognitiveComplexityVisitor) Visit(n ast.Node) ast.Visitor {
 		v.walk(1, n.Body)
 		return nil
 	case *ast.FuncLit:
-		v.walk(0, n.Body) // do not increment the complexity, just do the nesting
+		v.walk(0, n.Body) // do not increment the complexity
 		return nil
 	case *ast.BinaryExpr:
 		v.complexity += v.binExpComplexity(n)
@@ -140,10 +139,7 @@ func (v *cognitiveComplexityVisitor) Visit(n ast.Node) ast.Visitor {
 }
 
 func (v *cognitiveComplexityVisitor) walk(complexityIncrement int, targets ...ast.Node) {
-	v.complexity += complexityIncrement + v.nestingLevel
-	nesting := v.nestingLevel
-	v.nestingLevel++
-
+	v.complexity += complexityIncrement
 	for _, t := range targets {
 		if t == nil {
 			continue
@@ -151,8 +147,6 @@ func (v *cognitiveComplexityVisitor) walk(complexityIncrement int, targets ...as
 
 		ast.Walk(v, t)
 	}
-
-	v.nestingLevel = nesting
 }
 
 func (v *cognitiveComplexityVisitor) walkIfElse(n *ast.IfStmt) {
@@ -170,12 +164,9 @@ func (v *cognitiveComplexityVisitor) walkIfElse(n *ast.IfStmt) {
 		}
 	}
 
-	// Nesting level is incremented in 'if' and 'else' blocks, but only the first 'if' in an 'if-else-if' chain sees its
-	// complexity increased by the nesting level.
-	v.complexity += 1 + v.nestingLevel
-	v.nestingLevel++
+	// Only the first 'if' in an if-else-if chain increases the complexity by one.
+	v.complexity++
 	w(n)
-	v.nestingLevel--
 }
 
 func (*cognitiveComplexityVisitor) binExpComplexity(n *ast.BinaryExpr) int {

--- a/testdata/cognitive_complexity.go
+++ b/testdata/cognitive_complexity.go
@@ -62,10 +62,10 @@ func k(a, b, c, d, e, f bool) bool { // MATCH /function k has cognitive complexi
 }
 
 // Test nesting FOR expr + nested IF
-func l() { // MATCH /function l has cognitive complexity 6 (> max enabled 0)/
+func l() { // MATCH /function l has cognitive complexity 3 (> max enabled 0)/
 	for i := 1; i <= max; i++ { // +1
-		for j := 2; j < i; j++ { // +1 +1(nesting)
-			if i%j == 0 { // +1 +2(nesting)
+		for j := 2; j < i; j++ { // +1
+			if i%j == 0 { // +1
 				continue
 			}
 		}
@@ -76,10 +76,10 @@ func l() { // MATCH /function l has cognitive complexity 6 (> max enabled 0)/
 }
 
 // Test nesting IF
-func m() { // MATCH /function m has cognitive complexity 6 (> max enabled 0)/
+func m() { // MATCH /function m has cognitive complexity 3 (> max enabled 0)/
 	if i <= max { // +1
-		if j < i { // +1 +1(nesting)
-			if i%j == 0 { // +1 +2(nesting)
+		if j < i { // +1
+			if i%j == 0 { // +1
 				return 0
 			}
 		}
@@ -90,10 +90,10 @@ func m() { // MATCH /function m has cognitive complexity 6 (> max enabled 0)/
 }
 
 // Test nesting IF + nested FOR
-func n() { // MATCH /function n has cognitive complexity 6 (> max enabled 0)/
+func n() { // MATCH /function n has cognitive complexity 3 (> max enabled 0)/
 	if i > max { // +1
-		for j := 2; j < i; j++ { // +1 +1(nesting)
-			if i%j == 0 { // +1 +2(nesting)
+		for j := 2; j < i; j++ { // +1
+			if i%j == 0 { // +1
 				continue
 			}
 		}
@@ -104,10 +104,10 @@ func n() { // MATCH /function n has cognitive complexity 6 (> max enabled 0)/
 }
 
 // Test nesting
-func o() { // MATCH /function o has cognitive complexity 12 (> max enabled 0)/
+func o() { // MATCH /function o has cognitive complexity 6 (> max enabled 0)/
 	if i > max { // +1
-		if j < i { // +1 +1(nesting)
-			if i%j == 0 { // +1 +2(nesting)
+		if j < i { // +1
+			if i%j == 0 { // +1
 				return
 			}
 		}
@@ -116,8 +116,8 @@ func o() { // MATCH /function o has cognitive complexity 12 (> max enabled 0)/
 	}
 
 	if i > max { // +1
-		if j < i { // +1 +1(nesting)
-			if i%j == 0 { // +1 +2(nesting)
+		if j < i { // +1
+			if i%j == 0 { // +1
 				return
 			}
 		}
@@ -192,9 +192,9 @@ FirstLoop:
 }
 
 // Tests FUNC LITERAL
-func v() { // MATCH /function v has cognitive complexity 2 (> max enabled 0)/
+func v() { // MATCH /function v has cognitive complexity 1 (> max enabled 0)/
 	myFunc := func(b bool) {
-		if b { // +1 +1(nesting)
+		if b { // +1
 
 		}
 	}
@@ -204,21 +204,21 @@ func v() {
 	t.Run(tc.desc, func(t *testing.T) {})
 }
 
-func w() { // MATCH /function w has cognitive complexity 3 (> max enabled 0)/
+func w() { // MATCH /function w has cognitive complexity 2 (> max enabled 0)/
 	defer func(b bool) {
-		if b { // +1 +1(nesting)
+		if b { // +1
 
 		}
 	}(false || true) // +1
 }
 
 // Test from Cognitive Complexity white paper
-func sumOfPrimes(max int) int { // MATCH /function sumOfPrimes has cognitive complexity 7 (> max enabled 0)/
+func sumOfPrimes(max int) int { // MATCH /function sumOfPrimes has cognitive complexity 4 (> max enabled 0)/
 	total := 0
 OUT:
 	for i := 1; i <= max; i++ { // +1
-		for j := 2; j < i; j++ { // +1 +1(nesting)
-			if i%j == 0 { // +1 +2(nesting)
+		for j := 2; j < i; j++ { // +1
+			if i%j == 0 { // +1
 				continue OUT // +1
 			}
 		}
@@ -229,7 +229,7 @@ OUT:
 }
 
 // Test from K8S
-func (m *Migrator) MigrateIfNeeded(target *EtcdVersionPair) error { // MATCH /function (*Migrator).MigrateIfNeeded has cognitive complexity 18 (> max enabled 0)/
+func (m *Migrator) MigrateIfNeeded(target *EtcdVersionPair) error { // MATCH /function (*Migrator).MigrateIfNeeded has cognitive complexity 13 (> max enabled 0)/
 	klog.Infof("Starting migration to %s", target)
 	err := m.dataDirectory.Initialize(target)
 	if err != nil { // +1
@@ -243,7 +243,7 @@ func (m *Migrator) MigrateIfNeeded(target *EtcdVersionPair) error { // MATCH /fu
 	}
 	if vfExists { // +1
 		current, err = m.dataDirectory.versionFile.Read()
-		if err != nil { // +1 +1
+		if err != nil { // +1
 			return err
 		}
 	} else {
@@ -253,11 +253,11 @@ func (m *Migrator) MigrateIfNeeded(target *EtcdVersionPair) error { // MATCH /fu
 	for { // +1
 		klog.Infof("Converging current version '%s' to target version '%s'", current, target)
 		currentNextMinorVersion := &EtcdVersion{}
-		switch { // +1 +1
+		switch { // +1
 		case current.version.MajorMinorEquals(target.version) || currentNextMinorVersion.MajorMinorEquals(target.version): // +1
 			klog.Infof("current version '%s' equals or is one minor version previous of target version '%s' - migration complete", current, target)
 			err = m.dataDirectory.versionFile.Write(target)
-			if err != nil { // +1 +2
+			if err != nil { // +1
 				return fmt.Errorf("failed to write version.txt to '%s': %v", m.dataDirectory.path, err)
 			}
 			return nil
@@ -273,7 +273,7 @@ func (m *Migrator) MigrateIfNeeded(target *EtcdVersionPair) error { // MATCH /fu
 			klog.Infof("rolling etcd back from %s to %s", current, target)
 			current, err = m.rollbackEtcd3MinorVersion(current, target)
 		}
-		if err != nil { // +1 +1
+		if err != nil { // +1
 			return err
 		}
 	}

--- a/testdata/cognitive_complexity_default.go
+++ b/testdata/cognitive_complexity_default.go
@@ -6,6 +6,12 @@ func l() { // MATCH /function l has cognitive complexity 8 (> max enabled 7)/
 			if (i%j == 0) || (i%j == 1) {
 				continue
 			}
+			if j%2 == 0 {
+				total++
+			}
+			if j%3 == 0 && i%2 == 0 {
+				total++
+			}
 			total += i
 		}
 	}


### PR DESCRIPTION
## Summary
- remove nesting level from cognitive complexity calculations
- adjust tests for new cognitive complexity counts
- keep default complexity test at 8 with additional conditions

## Testing
- `go test ./...` *(fails: no route to host)*